### PR TITLE
Creates Related Labels

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "anomaly/tags-field_type",
+    "name": "psaunders/tags-field_type",
     "type": "streams-addon",
     "description": "A tags input field type.",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "psaunders/tags-field_type",
+    "name": "anomaly/tags-field_type",
     "type": "streams-addon",
     "description": "A tags input field type.",
     "keywords": [

--- a/src/TagsFieldType.php
+++ b/src/TagsFieldType.php
@@ -159,4 +159,31 @@ class TagsFieldType extends FieldType
 
         return $required;
     }
+
+
+    /**
+     * Gets entries that are related to this tag in the same entry table
+     *
+     * @param array $excluded The IDs of posts to exclude
+     * @return void
+     */
+    public function getRelated(array $excluded = null){
+
+        $query = $this->entry->query();
+
+        $query->where(function($queryGroup){
+            foreach($this->getValue() as $tag){
+               $queryGroup->orWhere('tags','like','%' . $tag . '%');
+            }
+            return $queryGroup;
+
+        });
+
+        if($excluded){
+            $query->whereNotIn($this->entry->getTableName().'.id',$excluded);
+        }
+
+        return $query->get();
+
+    }
 }

--- a/src/TagsFieldTypePresenter.php
+++ b/src/TagsFieldTypePresenter.php
@@ -23,7 +23,7 @@ class TagsFieldTypePresenter extends FieldTypePresenter
     /**
      * Return the tags wrapped in labels.
      *
-     * @param  string $class
+     * @param  string $class the class to give each tag
      * @return string
      */
     public function labels($class = 'tag-default')
@@ -34,6 +34,23 @@ class TagsFieldTypePresenter extends FieldTypePresenter
             },
             $this->object->getValue()
         );
+    }
+
+    /**
+     * Gets related entries and wraps in links
+     *
+     * @param  string $class the to give each tag
+     * @return string
+     */
+    public function relatedLabels($class = 'tag-default')
+    {
+        $links = '';
+
+        foreach($this->object->getRelated([$this->entry->id]) as $entry){
+            $links .= '<a class="tag ' . $class . '" href="'.$entry->route('view').'">' . $entry->title . '</a>';
+        }
+
+        return $links;
     }
 
     /**


### PR DESCRIPTION
A very common usage of tags is to allow readers of a post/page to find related or similar content (tag cloud, widget, recommended posts etc). This seems like a necessary addition to the field in order for it to be useful.

Not that familiar with CMS so style may be wrong.